### PR TITLE
Don't add the wrong default label function.

### DIFF
--- a/samples/ServerSide/ChartJs.Blazor.Sample.Serverside/wwwroot/dist/ChartJsInterop.js
+++ b/samples/ServerSide/ChartJs.Blazor.Sample.Serverside/wwwroot/dist/ChartJsInterop.js
@@ -99,11 +99,7 @@ function WireUpGenerateLabelsFunc(config) {
         var generateLabelsFunc = window[generateLabelsNamespaceAndFunc[0]][generateLabelsNamespaceAndFunc[1]];
         if (typeof generateLabels === "function") {
             config.options.legend.labels.generateLabels = generateLabelsFunc;
-        } else { // fallback to the default
-            config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
         }
-    } else { // fallback to the default
-        config.options.legend.labels.generateLabels = Chart.defaults.global.legend.labels.generateLabels;
     }
 }
 


### PR DESCRIPTION
The Chart.defaults.global.legend.labels.generateLabels added the wrong labels to the subdatas.

Somewhat fixes #5 