### PR TITLE
Fixed tooltips and added MaintainAspectRatio

### DIFF
--- a/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BubbleChartComponent.cshtml
+++ b/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BubbleChartComponent.cshtml
@@ -42,7 +42,7 @@
                 Display = true,
                 Responsive = true,
                 Title = new OptionsTitle { Display = true, Text = "I R TITLE" },
-                Tooltips = new Tooltips { Mode = Mode.point },
+                Tooltips = new Tooltips { InteractionMode = InteractionMode.Point },
             },
             Data = new BubbleChartData
             {

--- a/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/LineChart/FillLineChartComponent.cshtml
+++ b/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/LineChart/FillLineChartComponent.cshtml
@@ -44,7 +44,7 @@
                 Title = new OptionsTitle { Display = true, Text = "Fill Line Chart" },
                 Tooltips = new Tooltips
                 {
-                    Mode = Mode.nearest,
+                    InteractionMode = InteractionMode.Nearest,
                     Intersect = false
                 },
                 Scales = new Scales
@@ -73,7 +73,7 @@
                 Hover = new LineChartOptionsHover
                 {
                     Intersect = true,
-                    Mode = Mode.nearest
+                    InteractionMode = InteractionMode.Nearest
                 }
             },
             Data = new LineChartData

--- a/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/LineChart/LineChartComponent.cshtml
+++ b/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/LineChart/LineChartComponent.cshtml
@@ -53,7 +53,7 @@
                 },
                 Tooltips = new Tooltips
                 {
-                    Mode = Mode.nearest,
+                    InteractionMode = InteractionMode.Nearest,
                     Intersect = false
                 },
                 Scales = new Scales
@@ -82,7 +82,7 @@
                 Hover = new LineChartOptionsHover
                 {
                     Intersect = true,
-                    Mode = Mode.nearest
+                    InteractionMode = InteractionMode.Nearest
                 }
             },
             Data = new LineChartData

--- a/src/ChartJs.Blazor/ChartJS/Common/BaseChartConfigOptions.cs
+++ b/src/ChartJs.Blazor/ChartJS/Common/BaseChartConfigOptions.cs
@@ -7,6 +7,7 @@ namespace ChartJs.Blazor.ChartJS.Common
         public string Text { get; set; }
         public bool Display { get; set; }
         public bool Responsive { get; set; }
+        public bool MaintainAspectRatio { get; set; } = true;
 
         public Legend Legend { get; set; } = new Legend();
     }

--- a/src/ChartJs.Blazor/ChartJS/Common/InteractionMode.cs
+++ b/src/ChartJs.Blazor/ChartJS/Common/InteractionMode.cs
@@ -1,0 +1,28 @@
+﻿namespace ChartJs.Blazor.ChartJS.Common
+{
+    public class InteractionMode
+    {
+        /// <summary>
+        /// As per documentation here https://www.chartjs.org/docs/latest/general/interactions/modes.html
+        /// </summary>
+        public static readonly InteractionMode Point = new InteractionMode("point");
+        public static readonly InteractionMode Nearest = new InteractionMode("nearest");
+        public static readonly InteractionMode Index = new InteractionMode("index");
+        public static readonly InteractionMode Dataset = new InteractionMode("dataset");
+        public static readonly InteractionMode X = new InteractionMode("x");
+        public static readonly InteractionMode Y = new InteractionMode("y");
+
+
+        private readonly string _interactionmode;
+
+        public InteractionMode(string interactionMode)
+        {
+            _interactionmode = interactionMode;
+        }
+
+        public override string ToString()
+        {
+            return _interactionmode;
+        }
+    }
+}

--- a/src/ChartJs.Blazor/ChartJS/Common/Mode.cs
+++ b/src/ChartJs.Blazor/ChartJS/Common/Mode.cs
@@ -1,9 +1,0 @@
-﻿namespace ChartJs.Blazor.ChartJS.Common
-{
-    public enum Mode    
-    {
-        index,
-        nearest,
-        point
-    }
-}

--- a/src/ChartJs.Blazor/ChartJS/Common/Tooltips.cs
+++ b/src/ChartJs.Blazor/ChartJS/Common/Tooltips.cs
@@ -2,7 +2,7 @@
 {
     public class Tooltips
     {
-        public Mode Mode { get; set; }
+        public InteractionMode InteractionMode { get; set; }
         public bool Intersect { get; set; }
     }
 }

--- a/src/ChartJs.Blazor/ChartJS/LineChart/LineChartOptionsHover.cs
+++ b/src/ChartJs.Blazor/ChartJS/LineChart/LineChartOptionsHover.cs
@@ -4,7 +4,7 @@ namespace ChartJs.Blazor.ChartJS.LineChart
 {
     public class LineChartOptionsHover
     {
-        public Mode Mode { get; set; }
+        public InteractionMode InteractionMode { get; set; }
         public bool Intersect { get; set; }
         public long AnimationDuration { get; set; }
     }


### PR DESCRIPTION
As per commit text, Mode was converted to int(default enum), and chartjs need string.

Added MaintainAspectRatio, as I tried to get the graph to fill the page width, however unsuccessful.