### PR TITLE
Feature/linker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,3 +354,4 @@ MigrationBackup/
 
 #Rider stuff
 .idea/
+.vscode

--- a/samples/ClientSide/ChartJs.Blazor.Sample.ClientSide/ChartJs.Blazor.Sample.ClientSide.csproj
+++ b/samples/ClientSide/ChartJs.Blazor.Sample.ClientSide/ChartJs.Blazor.Sample.ClientSide.csproj
@@ -18,4 +18,8 @@
     <ProjectReference Include="..\..\Shared\ChartJs.Blazor.Sample.Shared\ChartJs.Blazor.Sample.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <BlazorLinkerDescriptor Include="Linker.xml" />
+  </ItemGroup>
+
 </Project>

--- a/samples/ClientSide/ChartJs.Blazor.Sample.ClientSide/Linker.xml
+++ b/samples/ClientSide/ChartJs.Blazor.Sample.ClientSide/Linker.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  This file specifies which parts of the BCL or Blazor packages must not be
+  stripped by the IL Linker even if they aren't referenced by user code.
+-->
+<linker>
+    <assembly fullname="mscorlib">
+        <!--
+          Preserve the methods in WasmRuntime because its methods are called by 
+          JavaScript client-side code to implement timers.
+          Fixes: https://github.com/aspnet/Blazor/issues/239
+        -->
+        <type fullname="System.Threading.WasmRuntime" />
+    </assembly>
+    <assembly fullname="System.Core">
+        <!--
+          System.Linq.Expressions* is required by Json.NET and any 
+          expression.Compile caller. The assembly isn't stripped.
+        -->
+        <type fullname="System.Linq.Expressions*" />
+    </assembly>
+    <!--
+      In this example, the app's entry point assembly is listed. The assembly
+      isn't stripped by the IL Linker.
+    -->
+    <assembly fullname="ChartJs.Blazor.Sample.ClientSide" />
+
+    <assembly fullname="System">
+        <type fullname="System.ComponentModel.ReferenceConverter">
+            <method signature="System.Void .ctor(System.Type)" />
+        </type>
+    </assembly>
+</linker>

--- a/samples/ClientSide/ChartJs.Blazor.Sample.ClientSide/Linker.xml
+++ b/samples/ClientSide/ChartJs.Blazor.Sample.ClientSide/Linker.xml
@@ -4,30 +4,31 @@
   stripped by the IL Linker even if they aren't referenced by user code.
 -->
 <linker>
-    <assembly fullname="mscorlib">
-        <!--
+  <assembly fullname="mscorlib">
+
+    <!--
           Preserve the methods in WasmRuntime because its methods are called by 
           JavaScript client-side code to implement timers.
           Fixes: https://github.com/aspnet/Blazor/issues/239
         -->
-        <type fullname="System.Threading.WasmRuntime" />
-    </assembly>
-    <assembly fullname="System.Core">
-        <!--
+    <type fullname="System.Threading.WasmRuntime" />
+  </assembly>
+  <assembly fullname="System.Core">
+
+    <!--
           System.Linq.Expressions* is required by Json.NET and any 
           expression.Compile caller. The assembly isn't stripped.
         -->
-        <type fullname="System.Linq.Expressions*" />
-    </assembly>
-    <!--
-      In this example, the app's entry point assembly is listed. The assembly
-      isn't stripped by the IL Linker.
-    -->
-    <assembly fullname="ChartJs.Blazor.Sample.ClientSide" />
+    <type fullname="System.Linq.Expressions*" />
+  </assembly>
 
-    <assembly fullname="System">
-        <type fullname="System.ComponentModel.ReferenceConverter">
-            <method signature="System.Void .ctor(System.Type)" />
-        </type>
-    </assembly>
+  <!-- The app's entry point assembly is listed. -->
+  <assembly fullname="ChartJs.Blazor.Sample.ClientSide" />
+
+  <!-- Take care of System.MissingMethodException: Constructor on type 'System.ComponentModel.ReferenceConverter' not found. -->
+  <assembly fullname="System">
+    <type fullname="System.ComponentModel.ReferenceConverter">
+      <method signature="System.Void .ctor(System.Type)" />
+    </type>
+  </assembly>
 </linker>

--- a/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BarCharts/HorizontalBarChartComponent.razor
+++ b/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BarCharts/HorizontalBarChartComponent.razor
@@ -1,5 +1,4 @@
-﻿@using System.ComponentModel
-@using ChartJs.Blazor.ChartJS.BarChart
+﻿@using ChartJs.Blazor.ChartJS.BarChart
 @using ChartJs.Blazor.ChartJS.Common.Axes
 @using ChartJs.Blazor.ChartJS.Common.Axes.Ticks
 @using ChartJs.Blazor.ChartJS.Common.Enums
@@ -11,95 +10,80 @@
 <div class="row">
 	<button class="btn btn-primary" @onclick="AddData">Add Data</button>
 	<button class="btn btn-primary" @onclick="RemoveData">Remove Data</button>
-	        </div>
-	        <ChartJsBarChart @ref="_barChart"
-	                          Config="@_barChartConfig"
-	                          Width="600"
-	                          Height="300"/>
+</div>
+<ChartJsBarChart @ref="_barChart"
+				 Config="@_barChartConfig"
+				 Width="600"
+				 Height="300"/>
 
-	        @code {
+@code {
 
-		        // https://github.com/Joelius300/ChartJSBlazor/issues/18
-//		        private ReferenceConverter _referenceConverter = new ReferenceConverter(typeof(ChartJsBarChart));
+	private BarConfig _barChartConfig;
+	private ChartJsBarChart _barChart;
+	private BarDataset<DoubleWrapper> _barDataSet;
 
-		        private BarConfig _barChartConfig;
-		        private ChartJsBarChart _barChart;
-		        private BarDataset<DoubleWrapper> _barDataSet;
+	protected override Task OnInitializedAsync() {
+		
+	//Note the constructor argument
+		_barChartConfig = new BarConfig(ChartType.HorizontalBar) {
+			Options = new BarOptions {
+				Title = new OptionsTitle {
+					Display = true,
+					Text = "Simple Bar Chart"
+				},
+				Responsive = true,
+				Scales = new BarScales {
+					XAxes = new List<CartesianAxis> {
+						new LinearCartesianAxis {
+							Ticks = new LinearCartesianTicks {
+								AutoSkip = false,
+								Min = 0 // Otherwise the lowest value in the dataset won't be visible
+							}
+						}
+					}
+				}
+			}
+		};
 
-		        protected override Task OnInitializedAsync()
-		        {
-		        //Note the constructor argument
-			        _barChartConfig = new BarConfig(ChartType.HorizontalBar)
-			        {
-				        Options = new BarOptions
-				        {
-					        Title = new OptionsTitle
-					        {
-						        Display = true,
-						        Text = "Simple Bar Chart"
-					        },
-					        Responsive = true,
-					        Scales = new BarScales
-					        {
-						        XAxes = new List<CartesianAxis>
-						        {
-							        new LinearCartesianAxis
-							        {
-								        Ticks = new LinearCartesianTicks
-								        {
-									        AutoSkip = false,
-									        Min = 0 // Otherwise the lowest value in the dataset won't be visible
-								        }
-							        }
-						        }
-					        }
-				        }
-			        };
+		_barChartConfig.Data.Labels.AddRange(new[] {"A", "B", "C", "D"});
 
-			        _barChartConfig.Data.Labels.AddRange(new[] {"A", "B", "C", "D"});
+	//Note the constructor argument
+		_barDataSet = new BarDataset<DoubleWrapper>(ChartType.HorizontalBar) {
+			Label = "My double dataset",
+			BackgroundColor = new[] {ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString()},
+			BorderColor = ColorUtil.RandomColorString(),
+			BorderWidth = 1
+		};
 
-		        //Note the constructor argument
-			        _barDataSet = new BarDataset<DoubleWrapper>(ChartType.HorizontalBar)
-			        {
-				        Label = "My double dataset",
-				        BackgroundColor = new[] {ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString()},
-				        BorderColor = ColorUtil.RandomColorString(),
-				        BorderWidth = 1
-			        };
+		_barDataSet.AddRange(new double[] {8, 5, 3, 7}.Wrap());
+		_barChartConfig.Data.Datasets.Add(_barDataSet);
 
-			        _barDataSet.AddRange(new double[] {8, 5, 3, 7}.Wrap());
-			        _barChartConfig.Data.Datasets.Add(_barDataSet);
+		return Task.CompletedTask;
+	}
 
-			        return Task.CompletedTask;
-		        }
+	private void AddData() {
+		var nowSecond = DateTime.Now.Second;
+		_barChartConfig.Data.Labels.Add(nowSecond.ToString());
+		_barDataSet.Add(new DoubleWrapper(nowSecond));
+		_barDataSet.BackgroundColor = _barChartConfig.Data.Labels.Select(l => ColorUtil.RandomColorString()).ToArray();
 
-		        private void AddData()
-		        {
-			        var nowSecond = DateTime.Now.Second;
-			        _barChartConfig.Data.Labels.Add(nowSecond.ToString());
-			        _barDataSet.Add(new DoubleWrapper(nowSecond));
-			        _barDataSet.BackgroundColor = _barChartConfig.Data.Labels.Select(l => ColorUtil.RandomColorString()).ToArray();
+		_barChartConfig.Options.Title.Text += DateTime.Now.Second.ToString();
 
-			        _barChartConfig.Options.Title.Text += DateTime.Now.Second.ToString();
+		_barChart.Update();
+	}
 
-			        _barChart.Update();
-		        }
-
-		        private void RemoveData()
-		        {
-			        if (_barChartConfig.Data.Labels.Count > 0)
-			        {
-				        _barChartConfig.Data.Labels.RemoveAt(_barChartConfig.Data.Labels.Count - 1);
-			        }
+	private void RemoveData() {
+		if (_barChartConfig.Data.Labels.Count > 0) {
+			_barChartConfig.Data.Labels.RemoveAt(_barChartConfig.Data.Labels.Count - 1);
+		}
 
 
-			        if (_barDataSet.Data.Count > 0)
-			        {
-				        _barDataSet.RemoveAt(_barDataSet.Data.Count - 1);
-			        }
+		if (_barDataSet.Data.Count > 0) {
+			_barDataSet.RemoveAt(_barDataSet.Data.Count - 1);
+		}
 
 
-			        _barChart.Update();
-		        }
+		_barChart.Update();
+	}
 
-	        }
+}

--- a/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BarCharts/HorizontalBarChartComponent.razor
+++ b/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BarCharts/HorizontalBarChartComponent.razor
@@ -20,7 +20,7 @@
 	        @code {
 
 		        // https://github.com/Joelius300/ChartJSBlazor/issues/18
-		        private ReferenceConverter _referenceConverter = new ReferenceConverter(typeof(ChartJsBarChart));
+//		        private ReferenceConverter _referenceConverter = new ReferenceConverter(typeof(ChartJsBarChart));
 
 		        private BarConfig _barChartConfig;
 		        private ChartJsBarChart _barChart;

--- a/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BarCharts/SimpleBarChartComponent.razor
+++ b/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BarCharts/SimpleBarChartComponent.razor
@@ -1,5 +1,4 @@
-﻿@using System.ComponentModel
-@using ChartJs.Blazor.ChartJS.BarChart
+﻿@using ChartJs.Blazor.ChartJS.BarChart
 @using ChartJs.Blazor.ChartJS.BarChart.Axes
 @using ChartJs.Blazor.ChartJS.Common.Axes
 @using ChartJs.Blazor.ChartJS.Common.Axes.Ticks
@@ -7,100 +6,87 @@
 @using ChartJs.Blazor.ChartJS.Common.Wrappers
 @using ChartJs.Blazor.Charts
 @using ChartJs.Blazor.Util
+
 <h2>Simple Bar Chart</h2>
 <div class="row">
-	<button class="btn btn-primary" @onclick="AddData">Add Data</button>
-	        <button class="btn btn-primary" @onclick="RemoveData">Remove Data</button>
-	                </div>
-	                <ChartJsBarChart @ref="_barChart"
-	                                  Config="@_barChartConfig"
-	                                  Width="600"
-	                                  Height="300"/>
+	<button class="btn btn-primary" @onclick="AddData">
+		Add Data
+	</button>
+	<button class="btn btn-primary" @onclick="RemoveData">
+		Remove Data
+	</button>
+</div>
+<ChartJsBarChart @ref="_barChart"
+				 Config="@_barChartConfig"
+				 Width="600"
+				 Height="300"/>
 
-	                @code {
+@code {
 
-		                // https://github.com/Joelius300/ChartJSBlazor/issues/18
-//		                private ReferenceConverter _referenceConverter = new ReferenceConverter(typeof(ChartJsBarChart));
+	private BarConfig _barChartConfig;
+	private ChartJsBarChart _barChart;
+	private BarDataset<DoubleWrapper> _barDataSet;
 
-		                private BarConfig _barChartConfig;
-		                private ChartJsBarChart _barChart;
-		                private BarDataset<DoubleWrapper> _barDataSet;
+	protected override void OnInitialized() {
+		_barChartConfig = new BarConfig {
+			Options = new BarOptions {
+				Title = new OptionsTitle {
+					Display = true,
+					Text = "Simple Bar Chart"
+				},
+				Scales = new BarScales {
+					XAxes = new List<CartesianAxis> {
+						new BarCategoryAxis {
+							BarPercentage = 0.5,
+							BarThickness = BarThickness.Flex
+						}
+					},
+					YAxes = new List<CartesianAxis> {
+						new BarLinearCartesianAxis {
+							Ticks = new LinearCartesianTicks {
+								BeginAtZero = true
+							}
+						}
+					}
+				}
+			}
+		};
 
-		                protected override void OnInitialized()
-		                {
-			                _barChartConfig = new BarConfig
-			                {
-				                Options = new BarOptions
-				                {
-					                Title = new OptionsTitle
-					                {
-						                Display = true,
-						                Text = "Simple Bar Chart"
-					                },
-					                Scales = new BarScales
-					                {
-						                XAxes = new List<CartesianAxis>
-						                {
-							                new BarCategoryAxis
-							                {
-								                BarPercentage = 0.5,
-								                BarThickness = BarThickness.Flex
-							                }
-						                },
-						                YAxes = new List<CartesianAxis>
-						                {
-							                new BarLinearCartesianAxis
-							                {
-								                Ticks = new LinearCartesianTicks
-								                {
-									                BeginAtZero = true
-								                }
-							                }
-						                }
-					                }
-				                }
-			                };
+		_barChartConfig.Data.Labels.AddRange(new[] {"A", "B", "C", "D"});
 
-			                _barChartConfig.Data.Labels.AddRange(new[] {"A", "B", "C", "D"});
+		_barDataSet = new BarDataset<DoubleWrapper> {
+			Label = "My double dataset",
+			BackgroundColor = new[] {ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString()},
+			BorderWidth = 0,
+			HoverBackgroundColor = ColorUtil.RandomColorString(),
+			HoverBorderColor = ColorUtil.RandomColorString(),
+			HoverBorderWidth = 1,
+			BorderColor = "#ffffff"
+		};
 
-			                _barDataSet = new BarDataset<DoubleWrapper>
-			                {
-				                Label = "My double dataset",
-				                BackgroundColor = new[] {ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString()},
-				                BorderWidth = 0,
-				                HoverBackgroundColor = ColorUtil.RandomColorString(),
-				                HoverBorderColor = ColorUtil.RandomColorString(),
-				                HoverBorderWidth = 1,
-				                BorderColor = "#ffffff"
-			                };
-
-			                _barDataSet.AddRange(new double[] {8, 5, 3, 7}.Wrap());
-			                _barChartConfig.Data.Datasets.Add(_barDataSet);
-		                }
+		_barDataSet.AddRange(new double[] {8, 5, 3, 7}.Wrap());
+		_barChartConfig.Data.Datasets.Add(_barDataSet);
+	}
 
 
-		                private void AddData()
-		                {
-			                var nowSecond = DateTime.Now.Second;
-			                _barChartConfig.Data.Labels.Add(nowSecond.ToString());
-			                _barDataSet.Add(new DoubleWrapper(nowSecond));
+	private void AddData() {
+		var nowSecond = DateTime.Now.Second;
+		_barChartConfig.Data.Labels.Add(nowSecond.ToString());
+		_barDataSet.Add(new DoubleWrapper(nowSecond));
 
-			                _barChart.Update();
-		                }
+		_barChart.Update();
+	}
 
-		                private void RemoveData()
-		                {
-			                if (_barChartConfig.Data.Labels.Count > 0)
-			                {
-				                _barChartConfig.Data.Labels.RemoveAt(_barChartConfig.Data.Labels.Count - 1);
-			                }
+	private void RemoveData() {
+		if (_barChartConfig.Data.Labels.Count > 0) {
+			_barChartConfig.Data.Labels.RemoveAt(_barChartConfig.Data.Labels.Count - 1);
+		}
 
-			                if (_barDataSet.Data.Count > 0)
-			                {
-				                _barDataSet.RemoveAt(_barDataSet.Data.Count - 1);
-			                }
+		if (_barDataSet.Data.Count > 0) {
+			_barDataSet.RemoveAt(_barDataSet.Data.Count - 1);
+		}
 
-			                _barChart.Update();
-		                }
+		_barChart.Update();
+	}
 
-	                }
+}

--- a/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BarCharts/SimpleBarChartComponent.razor
+++ b/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BarCharts/SimpleBarChartComponent.razor
@@ -20,7 +20,7 @@
 	                @code {
 
 		                // https://github.com/Joelius300/ChartJSBlazor/issues/18
-		                private ReferenceConverter _referenceConverter = new ReferenceConverter(typeof(ChartJsBarChart));
+//		                private ReferenceConverter _referenceConverter = new ReferenceConverter(typeof(ChartJsBarChart));
 
 		                private BarConfig _barChartConfig;
 		                private ChartJsBarChart _barChart;

--- a/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BarCharts/StackedBarChartComponent.razor
+++ b/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BarCharts/StackedBarChartComponent.razor
@@ -11,79 +11,68 @@
 <ChartJsBarChart @ref="_barChartJs" Config="@_config" Width="600" Height="300"/>
 
 @code {
-    private BarConfig _config;
-    private ChartJsBarChart _barChartJs;
+	private BarConfig _config;
+	private ChartJsBarChart _barChartJs;
 
-    protected override void OnInitialized()
-    {
-        _config = new BarConfig
-        {
-            Options = new BarOptions
-            {
-                Title = new OptionsTitle
-                {
-                    Display = true,
-                    Text = "Sample chart from Blazor"
-                },
-                Scales = new BarScales
-                {
-                    XAxes = new List<CartesianAxis>
-                    {
-                        new BarCategoryAxis
-                        {
-                            BarThickness = BarThickness.Flex,
-                            Stacked = true
-                        }
-                    }
-                },
-                Responsive = true
-            }
-        };
+	protected override void OnInitialized() {
+		_config = new BarConfig {
+			Options = new BarOptions {
+				Title = new OptionsTitle {
+					Display = true,
+					Text = "Sample chart from Blazor"
+				},
+				Scales = new BarScales {
+					XAxes = new List<CartesianAxis> {
+						new BarCategoryAxis {
+							BarThickness = BarThickness.Flex,
+							Stacked = true
+						}
+					}
+				},
+				Responsive = true
+			}
+		};
 
-        _config.Data.Labels.AddRange(new[] {"A", "B", "C", "D"});
+		_config.Data.Labels.AddRange(new[] {"A", "B", "C", "D"});
 
-        var barSet1 = new BarDataset<DoubleWrapper>
-        {
-            Label = "Red",
-            BackgroundColor = ColorUtil.RandomColorString(),
-            BorderWidth = 1,
-            HoverBackgroundColor = ColorUtil.ColorString(0, 0, 0, 0.1),
-            HoverBorderColor = ColorUtil.RandomColorString(),
-            HoverBorderWidth = 1,
-            BorderColor = "#ffffff",
-        };
+		var barSet1 = new BarDataset<DoubleWrapper> {
+			Label = "Red",
+			BackgroundColor = ColorUtil.RandomColorString(),
+			BorderWidth = 1,
+			HoverBackgroundColor = ColorUtil.ColorString(0, 0, 0, 0.1),
+			HoverBorderColor = ColorUtil.RandomColorString(),
+			HoverBorderWidth = 1,
+			BorderColor = "#ffffff",
+		};
 
-        barSet1.AddRange(new double[] {4, 3, 2, 1}.Wrap());
-        _config.Data.Datasets.Add(barSet1);
+		barSet1.AddRange(new double[] {4, 3, 2, 1}.Wrap());
+		_config.Data.Datasets.Add(barSet1);
 
-        var barSet2 = new BarDataset<DoubleWrapper>
-        {
-            Label = "Green",
-            BackgroundColor = ColorUtil.RandomColorString(),
-            BorderWidth = 1,
-            HoverBackgroundColor = ColorUtil.ColorString(0, 0, 0, 0.1),
-            HoverBorderColor = ColorUtil.RandomColorString(),
-            HoverBorderWidth = 1,
-            BorderColor = "#ffffff",
-        };
+		var barSet2 = new BarDataset<DoubleWrapper> {
+			Label = "Green",
+			BackgroundColor = ColorUtil.RandomColorString(),
+			BorderWidth = 1,
+			HoverBackgroundColor = ColorUtil.ColorString(0, 0, 0, 0.1),
+			HoverBorderColor = ColorUtil.RandomColorString(),
+			HoverBorderWidth = 1,
+			BorderColor = "#ffffff",
+		};
 
-        barSet2.AddRange(new double[] {1, 5, 10, 15}.Wrap());
-        _config.Data.Datasets.Add(barSet2);
+		barSet2.AddRange(new double[] {1, 5, 10, 15}.Wrap());
+		_config.Data.Datasets.Add(barSet2);
 
-        var barSet3 = new BarDataset<DoubleWrapper>
-        {
-            Label = "Blue",
-            BackgroundColor = ColorUtil.RandomColorString(),
-            BorderWidth = 1,
-            HoverBackgroundColor = ColorUtil.ColorString(0, 0, 0, 0.1),
-            HoverBorderColor = ColorUtil.RandomColorString(),
-            HoverBorderWidth = 1,
-            BorderColor = "#ffffff",
-        };
+		var barSet3 = new BarDataset<DoubleWrapper> {
+			Label = "Blue",
+			BackgroundColor = ColorUtil.RandomColorString(),
+			BorderWidth = 1,
+			HoverBackgroundColor = ColorUtil.ColorString(0, 0, 0, 0.1),
+			HoverBorderColor = ColorUtil.RandomColorString(),
+			HoverBorderWidth = 1,
+			BorderColor = "#ffffff",
+		};
 
-        barSet3.AddRange(new double[] {5, 6, 7, 8}.Wrap());
-        _config.Data.Datasets.Add(barSet3);
-    }
-
+		barSet3.AddRange(new double[] {5, 6, 7, 8}.Wrap());
+		_config.Data.Datasets.Add(barSet3);
+	}
 
 }

--- a/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BarCharts/TimeBarChartComponent.razor
+++ b/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/BarCharts/TimeBarChartComponent.razor
@@ -10,67 +10,55 @@
 
 <h1>Time Bar Chart</h1>
 
-<ChartJsBarChart @ref="_barChartJs" Config="@_config" Width="600" Height="300" />
+<ChartJsBarChart @ref="_barChartJs" Config="@_config" Width="600" Height="300"/>
 
 @code {
-    private BarConfig _config;
-    private ChartJsBarChart _barChartJs;
+	private BarConfig _config;
+	private ChartJsBarChart _barChartJs;
 
-    protected override void OnInitialized()
-    {
-        _config = new BarConfig
-        {
-            Options = new BarOptions
-            {
-                Title = new OptionsTitle
-                {
-                    Display = true,
-                    Text = "Sample chart from Blazor"
-                },
-                Scales = new BarScales
-                {
-                    XAxes = new List<CartesianAxis>
-                {
-                        new BarTimeAxis
-                        {
-                            BarPercentage = 0.75,
-                            Time = new TimeOptions
-                            {
-                                Unit = TimeMeasurement.Hour
-                            },
-                            Offset = true
-                        }
-                    },
-                    YAxes = new List<CartesianAxis>
-                {
-                        new BarLinearCartesianAxis
-                        {
-                            Ticks = new LinearCartesianTicks
-                            {
-                                BeginAtZero = true
-                            }
-                        }
-                    }
-                },
-                Responsive = true
-            }
-        };
+	protected override void OnInitialized() {
+		_config = new BarConfig {
+			Options = new BarOptions {
+				Title = new OptionsTitle {
+					Display = true,
+					Text = "Sample chart from Blazor"
+				},
+				Scales = new BarScales {
+					XAxes = new List<CartesianAxis> {
+						new BarTimeAxis {
+							BarPercentage = 0.75,
+							Time = new TimeOptions {
+								Unit = TimeMeasurement.Hour
+							},
+							Offset = true
+						}
+					},
+					YAxes = new List<CartesianAxis> {
+						new BarLinearCartesianAxis {
+							Ticks = new LinearCartesianTicks {
+								BeginAtZero = true
+							}
+						}
+					}
+				},
+				Responsive = true
+			}
+		};
 
-        var barSet = new BarDataset<TimeTuple<double>>
-        {
-            Label = "My time-double dataset",
-            BackgroundColor = new[] { ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString() },
-            BorderWidth = 1,
-            HoverBackgroundColor = ColorUtil.ColorString(0, 0, 0, 0.1),
-            HoverBorderColor = "#020202",
-            HoverBorderWidth = 1,
-            BorderColor = "#ffffff"
-        };
+		var barSet = new BarDataset<TimeTuple<double>> {
+			Label = "My time-double dataset",
+			BackgroundColor = new[] {ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString()},
+			BorderWidth = 1,
+			HoverBackgroundColor = ColorUtil.ColorString(0, 0, 0, 0.1),
+			HoverBorderColor = "#020202",
+			HoverBorderWidth = 1,
+			BorderColor = "#ffffff"
+		};
 
-        var now = DateTime.Now;
-        var rnd = new Random();
-        barSet.AddRange(Enumerable.Range(2, 4).Select(i => new TimeTuple<double>((Moment)now.AddHours(i), rnd.NextDouble() * 4)));
-        _config.Data.Datasets.Add(barSet);
-    }
+		var now = DateTime.Now;
+		var rnd = new Random();
+		barSet.AddRange(Enumerable.Range(2, 4).Select(i => new TimeTuple<double>((Moment) now.AddHours(i), rnd.NextDouble() * 4)));
+		_config.Data.Datasets.Add(barSet);
+	}
 
 }

--- a/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/Fun/SineLineChartComponent.razor
+++ b/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/Fun/SineLineChartComponent.razor
@@ -5,7 +5,6 @@
 @using ChartJs.Blazor.ChartJS.Common.Axes.Ticks
 @using ChartJs.Blazor.ChartJS.Common.Properties
 @using ChartJs.Blazor.ChartJS.Common.Enums
-@using ChartJs.Blazor.ChartJS.Common.Time
 @using ChartJs.Blazor.ChartJS.LineChart
 @using ChartJs.Blazor.Util
 
@@ -13,119 +12,99 @@
 
 <h2>Linear Line Chart</h2>
 <ChartJsLineChart @ref="_lineChartJs" Config="@_lineConfig" Width="600" Height="300"/>
-<Button @onclick="Start">Start</Button>
-<Button @onclick="Stop">Stop</Button>
+<button @onclick="Start">Start</button>
+<button @onclick="Stop">Stop</button>
 
 @code
 {
-    LineConfig _lineConfig;
-    ChartJsLineChart _lineChartJs;
+	LineConfig _lineConfig;
+	ChartJsLineChart _lineChartJs;
 
-    private LineDataset<Point> _sineSet;
+	private LineDataset<Point> _sineSet;
 
-    private Timer _timer;
-    private DateTime _startTime;
+	private Timer _timer;
+	private DateTime _startTime;
 
-    protected override void OnInitialized()
-    {
-        _lineConfig = new LineConfig
-        {
-            Options = new LineOptions
-            {
-                Responsive = true,
-                Title = new OptionsTitle
-                {
-                    Display = true,
-                    Text = "Line Chart"
-                },
-                Scales = new Scales
-                {
-                    xAxes = new List<CartesianAxis>
-                    {
-                        new LinearCartesianAxis
-                        {
-                            ScaleLabel = new ScaleLabel
-                            {
-                                LabelString = "Zeit"
-                            },
-                            GridLines = new GridLines
-                            {
-                                Display = false
-                            },
-                            Ticks = new LinearCartesianTicks
-                            {
-                                SuggestedMin = -2
-                            }
-                        }
-                    },
-                    yAxes = new List<CartesianAxis>
-                    {
-                        new LinearCartesianAxis
-                        {
-                            ScaleLabel = new ScaleLabel
-                            {
-                                LabelString = "Temp"
-                            }
-                        }
-                    }
-                },
-                Hover = new LineOptionsHover
-                {
-                    Intersect = true,
-                    Mode = InteractionMode.Y
-                }
-            }
-        };
+	protected override void OnInitialized() {
+		_lineConfig = new LineConfig {
+			Options = new LineOptions {
+				Responsive = true,
+				Title = new OptionsTitle {
+					Display = true,
+					Text = "Line Chart"
+				},
+				Scales = new Scales {
+					xAxes = new List<CartesianAxis> {
+						new LinearCartesianAxis {
+							ScaleLabel = new ScaleLabel {
+								LabelString = "Zeit"
+							},
+							GridLines = new GridLines {
+								Display = false
+							},
+							Ticks = new LinearCartesianTicks {
+								SuggestedMin = -2
+							}
+						}
+					},
+					yAxes = new List<CartesianAxis> {
+						new LinearCartesianAxis {
+							ScaleLabel = new ScaleLabel {
+								LabelString = "Temp"
+							}
+						}
+					}
+				},
+				Hover = new LineOptionsHover {
+					Intersect = true,
+					Mode = InteractionMode.Y
+				}
+			}
+		};
 
-        _sineSet = new LineDataset<Point>
-        {
-            BackgroundColor = ColorUtil.ColorString(0, 255, 0, 1.0),
-            BorderColor = ColorUtil.ColorString(0, 0, 255, 1.0),
-            Label = "Temp (C) per Hour",
-            Fill = false,
-            PointBackgroundColor = ColorUtil.RandomColorString(),
-            BorderWidth = 1,
-            PointRadius = 3,
-            PointBorderWidth = 1,
-        };
+		_sineSet = new LineDataset<Point> {
+			BackgroundColor = ColorUtil.ColorString(0, 255, 0, 1.0),
+			BorderColor = ColorUtil.ColorString(0, 0, 255, 1.0),
+			Label = "Temp (C) per Hour",
+			Fill = false,
+			PointBackgroundColor = ColorUtil.RandomColorString(),
+			BorderWidth = 1,
+			PointRadius = 3,
+			PointBorderWidth = 1,
+		};
 
-        _lineConfig.Data.Datasets.Add(_sineSet);
+		_lineConfig.Data.Datasets.Add(_sineSet);
 
-        _timer = new Timer(300) {AutoReset = true};
-        _timer.Elapsed += TimerOnElapsed;
-    }
+		_timer = new Timer(300) {AutoReset = true};
+		_timer.Elapsed += TimerOnElapsed;
+	}
 
-    private void TimerOnElapsed(object sender, ElapsedEventArgs e)
-    {
-        var x = (DateTime.Now - _startTime).TotalMilliseconds;
-        var fileTimeAsRadians = x * 0.0174533;
-        _sineSet.Add(new Point(x, Math.Sin(fileTimeAsRadians)));
+	private void TimerOnElapsed(object sender, ElapsedEventArgs e) {
+		var x = (DateTime.Now - _startTime).TotalMilliseconds;
+		var fileTimeAsRadians = x * 0.0174533;
+		_sineSet.Add(new Point(x, Math.Sin(fileTimeAsRadians)));
 
-        if (_sineSet.Data.Count > 100)
-        {
-            _sineSet.RemoveAt(0); 
-        }
+		if (_sineSet.Data.Count > 100) {
+			_sineSet.RemoveAt(0);
+		}
 
-        _lineChartJs.Update();
+		_lineChartJs.Update();
 
-        //InvokeAsync(StateHasChanged);
-    }
+	//InvokeAsync(StateHasChanged);
+	}
 
-    private void Start()
-    {
-        _startTime = DateTime.Now;
-        
-        _timer.Start();
-    }
+	private void Start() {
+		_startTime = DateTime.Now;
 
-    private void Stop()
-    {
-        _timer.Stop();
-    }
+		_timer.Start();
+	}
 
-    public void Dispose()
-    {
-        _timer?.Dispose();
-    }
+	private void Stop() {
+		_timer.Stop();
+	}
+
+	public void Dispose() {
+		_timer?.Dispose();
+	}
 
 }

--- a/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/PieChartComponent.razor
+++ b/samples/Shared/ChartJs.Blazor.Sample.Shared/Components/PieChartComponent.razor
@@ -1,6 +1,4 @@
-﻿@using System.Collections
-@using System.Globalization
-@using ChartJs.Blazor.ChartJS.Common
+﻿@using System.Globalization
 @using ChartJs.Blazor.Charts
 @using ChartJs.Blazor.ChartJS.PieChart
 @using ChartJs.Blazor.ChartJS.Common.Properties
@@ -12,124 +10,110 @@
 
 
 <div class="container">
-    <div class="row">
-        <div class="col">
-            <button class="btn btn-primary" @onclick="AddData">Add data</button>
-                    </div>
-                    <div class="col">
-                        <button class="btn btn-outline-danger" @onclick="RemoveData">Remove data</button>
-                                </div>
-                                </div>
-                                <div class="row">
-                                    <div class="col">
-                                        <button class="btn btn-primary" @onclick="AddDataset">Add dataset</button>
-                                                </div>
-                                                <div class="col">
-                                                    <button class="btn btn-outline-danger" @onclick="RemoveDataset">Remove dataset</button>
-                                                            </div>
-                                                            </div>
-                                                            </div>
+	<div class="row">
+		<div class="col">
+			<button class="btn btn-primary" @onclick="AddData">Add data</button>
+		</div>
+		<div class="col">
+			<button class="btn btn-outline-danger" @onclick="RemoveData">Remove data</button>
+		</div>
+	</div>
+	<div class="row">
+		<div class="col">
+			<button class="btn btn-primary" @onclick="AddDataset">Add dataset</button>
+		</div>
+		<div class="col">
+			<button class="btn btn-outline-danger" @onclick="RemoveDataset">Remove dataset</button>
+		</div>
+	</div>
+</div>
 
-                                                            @code {
-                                                                private PieConfig _config;
-                                                                private ChartJsPieChart _pieChartJs;
+@code {
+	private PieConfig _config;
+	private ChartJsPieChart _pieChartJs;
 
-                                                                protected override void OnInitialized()
-                                                                {
-                                                                    _config = new PieConfig
-                                                                    {
-                                                                        Options = new PieOptions
-                                                                        {
-                                                                            Title = new OptionsTitle
-                                                                            {
-                                                                                Display = true,
-                                                                                Text = "Sample chart from Blazor"
-                                                                            },
-                                                                            Responsive = true,
-                                                                            Animation = new ArcAnimation
-                                                                            {
-                                                                                AnimateRotate = true,
-                                                                                AnimateScale = true
-                                                                            }
-                                                                        }
-                                                                    };
+	protected override void OnInitialized() {
+		_config = new PieConfig {
+			Options = new PieOptions {
+				Title = new OptionsTitle {
+					Display = true,
+					Text = "Sample chart from Blazor"
+				},
+				Responsive = true,
+				Animation = new ArcAnimation {
+					AnimateRotate = true,
+					AnimateScale = true
+				}
+			}
+		};
 
-                                                                    _config.Data.Labels.AddRange(new[] {"A", "B", "C", "D"});
+		_config.Data.Labels.AddRange(new[] {"A", "B", "C", "D"});
 
-                                                                    var pieSet = new PieDataset
-                                                                    {
-                                                                        BackgroundColor = new[] {ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString()},
-                                                                        BorderWidth = 0,
-                                                                        HoverBackgroundColor = ColorUtil.RandomColorString(),
-                                                                        HoverBorderColor = ColorUtil.RandomColorString(),
-                                                                        HoverBorderWidth = 1,
-                                                                        BorderColor = "#ffffff",
-                                                                    };
+		var pieSet = new PieDataset {
+			BackgroundColor = new[] {ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString(), ColorUtil.RandomColorString()},
+			BorderWidth = 0,
+			HoverBackgroundColor = ColorUtil.RandomColorString(),
+			HoverBorderColor = ColorUtil.RandomColorString(),
+			HoverBorderWidth = 1,
+			BorderColor = "#ffffff",
+		};
 
-                                                                    pieSet.Data.AddRange(new double[] {4, 5, 6, 7});
-                                                                    _config.Data.Datasets.Add(pieSet);
-                                                                }
+		pieSet.Data.AddRange(new double[] {4, 5, 6, 7});
+		_config.Data.Datasets.Add(pieSet);
+	}
 
-                                                                private void AddData()
-                                                                {
-                                                                    var dataset = _config.Data.Datasets.LastOrDefault();
-                                                                    if (dataset == null)
-                                                                    {
-                                                                        return;
-                                                                    }
+	private void AddData() {
+		var dataset = _config.Data.Datasets.LastOrDefault();
+		if (dataset == null) {
+			return;
+		}
 
-                                                                    var rand = new Random();
-                                                                    var newVal = 1 + rand.NextDouble() * 10;
-                                                                    _config.Data.Labels.Add(newVal.ToString(CultureInfo.InvariantCulture));
-                                                                    dataset.Data.Add(newVal);
-                                                                    dataset.BackgroundColor = dataset.BackgroundColor.IndexedValues.Append(ColorUtil.RandomColorString()).ToArray();
+		var rand = new Random();
+		var newVal = 1 + rand.NextDouble() * 10;
+		_config.Data.Labels.Add(newVal.ToString(CultureInfo.InvariantCulture));
+		dataset.Data.Add(newVal);
+		dataset.BackgroundColor = dataset.BackgroundColor.IndexedValues.Append(ColorUtil.RandomColorString()).ToArray();
 
-                                                                    _pieChartJs.Update();
-                                                                }
+		_pieChartJs.Update();
+	}
 
-                                                                private void RemoveData()
-                                                                {
-                                                                    var dataset = _config.Data.Datasets.LastOrDefault();
-                                                                    if (dataset == null || dataset.Data.Count < 1)
-                                                                    {
-                                                                        return;
-                                                                    }
+	private void RemoveData() {
+		var dataset = _config.Data.Datasets.LastOrDefault();
+		if (dataset == null || dataset.Data.Count < 1) {
+			return;
+		}
 
-                                                                    _config.Data.Labels.RemoveAt(_config.Data.Labels.Count - 1);
-                                                                    dataset.Data.RemoveAt(dataset.Data.Count - 1);
+		_config.Data.Labels.RemoveAt(_config.Data.Labels.Count - 1);
+		dataset.Data.RemoveAt(dataset.Data.Count - 1);
 
-                                                                    _pieChartJs.Update();
-                                                                }
+		_pieChartJs.Update();
+	}
 
-                                                                private void AddDataset()
-                                                                {
-                                                                    var pieSet = new PieDataset
-                                                                    {
-                                                                        BorderWidth = 0,
-                                                                        HoverBackgroundColor = ColorUtil.RandomColorString(),
-                                                                        HoverBorderColor = ColorUtil.RandomColorString(),
-                                                                        HoverBorderWidth = 1,
-                                                                        BorderColor = "#ffffff",
-                                                                    };
+	private void AddDataset() {
+		var pieSet = new PieDataset {
+			BorderWidth = 0,
+			HoverBackgroundColor = ColorUtil.RandomColorString(),
+			HoverBorderColor = ColorUtil.RandomColorString(),
+			HoverBorderWidth = 1,
+			BorderColor = "#ffffff",
+		};
 
-                                                                // determine the number of data points to add
-                                                                    var count = _config.Data.Labels.Count;
+	// determine the number of data points to add
+		var count = _config.Data.Labels.Count;
 
-                                                                    var rand = new Random();
-                                                                    pieSet.Data.AddRange(Enumerable.Range(0, count).Select(i => Convert.ToDouble(rand.Next(0, 10))));
-                                                                    pieSet.BackgroundColor = Enumerable.Range(0, count).Select(i => ColorUtil.RandomColorString()).ToArray();
+		var rand = new Random();
+		pieSet.Data.AddRange(Enumerable.Range(0, count).Select(i => Convert.ToDouble(rand.Next(0, 10))));
+		pieSet.BackgroundColor = Enumerable.Range(0, count).Select(i => ColorUtil.RandomColorString()).ToArray();
 
-                                                                    _config.Data.Datasets.Add(pieSet);
-                                                                    _pieChartJs.Update();
-                                                                }
+		_config.Data.Datasets.Add(pieSet);
+		_pieChartJs.Update();
+	}
 
-                                                                private void RemoveDataset()
-                                                                {
-                                                                    if (_config.Data.Datasets.Count > 1)
-                                                                    {
-                                                                        _config.Data.Datasets.RemoveAt(_config.Data.Datasets.Count - 1);
-                                                                        _pieChartJs.Update();
-                                                                    }
-                                                                }
+	private void RemoveDataset() {
+		if (_config.Data.Datasets.Count > 1) {
+			_config.Data.Datasets.RemoveAt(_config.Data.Datasets.Count - 1);
+			_pieChartJs.Update();
+		}
+	}
 
-                                                            }
+}


### PR DESCRIPTION
Added a linker config file to address the problem that a constructor (`System.ComponentModel.ReferenceConverter`) was stripped even though it is used.
This has the advantage that it resolves the problem in an explicit way, as opposed to implicitly fixing it by calling that constructor without using it.

The documentation was also updated to explain the necessity for a linker config.

Unrelated: I fixed the horribly formatting of a few sample components (boy scout rule)