### PR TITLE
Fix for AspectRatio configuration

### DIFF
--- a/src/ChartJs.Blazor/Charts/ChartBase.cs
+++ b/src/ChartJs.Blazor/Charts/ChartBase.cs
@@ -25,13 +25,13 @@ namespace ChartJs.Blazor.Charts
         /// The width of the canvas HTML element used to draw the chart.
         /// </summary>
         [Parameter]
-        public int? Width { get; set; };
+        public int? Width { get; set; }
 
         /// <summary>
         /// The height of the canvas HTML element used to draw the chart. Use null value when using AspectRatio.
         /// </summary>
         [Parameter]
-        public int? Height { get; set; };
+        public int? Height { get; set; }
 
         /// <inheritdoc />
         protected override Task OnAfterRenderAsync(bool firstRender)

--- a/src/ChartJs.Blazor/Charts/ChartBase.cs
+++ b/src/ChartJs.Blazor/Charts/ChartBase.cs
@@ -25,13 +25,13 @@ namespace ChartJs.Blazor.Charts
         /// The width of the canvas HTML element used to draw the chart.
         /// </summary>
         [Parameter]
-        public int? Width { get; set; } = null;
+        public int? Width { get; set; };
 
         /// <summary>
         /// The height of the canvas HTML element used to draw the chart. Use null value when using AspectRatio.
         /// </summary>
         [Parameter]
-        public int? Height { get; set; } = null;
+        public int? Height { get; set; };
 
         /// <inheritdoc />
         protected override Task OnAfterRenderAsync(bool firstRender)

--- a/src/ChartJs.Blazor/Charts/ChartBase.cs
+++ b/src/ChartJs.Blazor/Charts/ChartBase.cs
@@ -25,13 +25,13 @@ namespace ChartJs.Blazor.Charts
         /// The width of the canvas HTML element used to draw the chart.
         /// </summary>
         [Parameter]
-        public int Width { get; set; } = 400;
+        public int? Width { get; set; } = null;
 
         /// <summary>
-        /// The height of the canvas HTML element used to draw the chart.
+        /// The height of the canvas HTML element used to draw the chart. Use null value when using AspectRatio.
         /// </summary>
         [Parameter]
-        public int Height { get; set; } = 400;
+        public int? Height { get; set; } = null;
 
         /// <inheritdoc />
         protected override Task OnAfterRenderAsync(bool firstRender)


### PR DESCRIPTION
Making it possible to **not** set width/height on chart canvas. This is required for AspectRatio to work.
I removed the default settings for width/height of 400/400 since it makes more sense to not have the canvas width/height set by default.

- As stated here: https://www.chartjs.org/docs/latest/general/responsive.html#configuration-options
AspectRatio - "Note that this option is ignored if the height is explicitly defined either as attribute or via the style."