### PR TITLE
Add plugin support

### DIFF
--- a/src/ChartJs.Blazor/ChartJS/Common/BaseConfigOptions.cs
+++ b/src/ChartJs.Blazor/ChartJS/Common/BaseConfigOptions.cs
@@ -1,6 +1,8 @@
 ﻿using ChartJs.Blazor.ChartJS.Common.Handlers;
 using ChartJs.Blazor.ChartJS.Common.Handlers.OnClickHandler;
 using ChartJs.Blazor.ChartJS.Common.Properties;
+using System;
+using System.Collections.Generic;
 
 namespace ChartJs.Blazor.ChartJS.Common
 {
@@ -51,8 +53,25 @@ namespace ChartJs.Blazor.ChartJS.Common
         /// </summary>
         public Animation Animation { get; set; }
 
+        /// <summary>
+        /// Gets the plugin options. The key has to be the unique
+        /// identification of the plugin.
+        /// <para>
+        /// Reference for chart.js plugin options: 
+        /// <a href="https://www.chartjs.org/docs/latest/developers/plugins.html#plugin-options"/>
+        /// </para>
+        /// </summary>
+        public Dictionary<string, object> Plugins { get; } = new Dictionary<string, object>();
+
         public IClickHandler OnClick { get; set; }
 
         public Hover Hover { get; set; }
+
+        /// <summary>
+        /// This method tells json.net to only serialize the plugin options when
+        /// there are plugin options, don't call it directly.
+        /// </summary>
+        [Obsolete("Only for json.net, don't call it.", true)]
+        public bool ShouldSerializePlugins() => Plugins.Count > 0;
     }
 }

--- a/src/ChartJs.Blazor/ChartJS/Common/ConfigBase.cs
+++ b/src/ChartJs.Blazor/ChartJS/Common/ConfigBase.cs
@@ -1,59 +1,85 @@
 using ChartJs.Blazor.ChartJS.Common.Enums;
 using System;
+using System.Collections.Generic;
 
 namespace ChartJs.Blazor.ChartJS.Common
 {
     /// <summary>
     /// Base class for chart-configs
-    /// <para>Contains the most basic required information about a chart</para>
+    /// <para>Contains the most basic required information about a chart.</para>
     /// </summary>
     public abstract class ConfigBase
     {
         /// <summary>
-        /// Creates a new instance of <see cref="ConfigBase"/>
+        /// Creates a new instance of <see cref="ConfigBase"/>.
         /// </summary>
-        /// <param name="chartType">The chartType this config is for</param>
+        /// <param name="chartType">The <see cref="ChartType"/> this config is for.</param>
         protected ConfigBase(ChartType chartType)
         {
             Type = chartType;
         }
 
         /// <summary>
-        /// Defines what type of chart this config is for
+        /// Gets the type of chart this config is for.
         /// </summary>
         public ChartType Type { get; }
 
         /// <summary>
-        /// The id for the html canvas element associated with this chart
+        /// Gets the id for the html canvas element associated with this chart.
+        /// This property is initialized to a random GUID-string upon creation.
         /// </summary>
         public string CanvasId { get; } = Guid.NewGuid().ToString();
+
+        /// <summary>
+        /// Gets the list of inline plugins for this chart. Consider
+        /// registering global plugins (through JavaScript) or assigning the
+        /// plugins through JavaScript instead of using this property
+        /// since these plugins work mostly with method hooks and methods
+        /// can't be serialized. It could be supported, but just isn't yet.
+        /// <para>
+        /// Reference for chart.js inline plugins: 
+        /// <a href="https://www.chartjs.org/docs/latest/developers/plugins.html#using-plugins"/>
+        /// </para>
+        /// <para>
+        /// For configuring plugins (plugin options), you need to use
+        /// <see cref="BaseConfigOptions.Plugins"/> instead.
+        /// </para>
+        /// </summary>
+        public List<object> Plugins { get; } = new List<object>();
+        
+        /// <summary>
+        /// This method tells json.net to only serialize the plugins when there
+        /// are plugins, don't call it directly.
+        /// </summary>
+        [Obsolete("Only for json.net, don't call it.", true)]
+        public bool ShouldSerializePlugins() => Plugins.Count > 0;
     }
 
     /// <summary>
-    /// Base class for chart-config which contains the options and the data sub-configs
+    /// Base class for chart-configs which contains the options and the data subconfigs.
     /// </summary>
-    /// <typeparam name="TOptions">The type of the options-subconfig</typeparam>
-    /// <typeparam name="TData">The type of the data-subconfig</typeparam>
+    /// <typeparam name="TOptions">The type of the options subconfig.</typeparam>
+    /// <typeparam name="TData">The type of the data subconfig.</typeparam>
     public abstract class ConfigBase<TOptions, TData> : ConfigBase
         where TOptions : BaseConfigOptions
         where TData : class, new()      // TODO: restrict to some interface
     {
         /// <summary>
-        /// Creates a new instance of <see cref="ConfigBase"/>
+        /// Creates a new instance of <see cref="ConfigBase"/>.
         /// </summary>
-        /// <param name="chartType">The chartType this config is for</param>
+        /// <param name="chartType">The <see cref="ChartType"/> this config is for.</param>
         protected ConfigBase(ChartType chartType) : base(chartType)
         {
             Data = new TData();
         }
 
         /// <summary>
-        /// The options subconfig for this chart
+        /// Gets or sets the options subconfig for this chart.
         /// </summary>
         public TOptions Options { get; set; }
 
         /// <summary>
-        /// The data subconfig for this chart
+        /// Gets the data subconfig for this chart.
         /// </summary>
         public TData Data { get; }
     }


### PR DESCRIPTION
Adds the two main properties for plugins. 
- [Inline plugins](https://www.chartjs.org/docs/latest/developers/plugins.html#using-plugins) on chart level
- [Plugin options](https://www.chartjs.org/docs/latest/developers/plugins.html#plugin-options) on option level

fixes #63

Currently only the plugin options really make sense, the plugin implementations aren't really helpful when serialized from C#. We could however add a base class for plugins where you can assign methods with the hooks but that would require some additional code in the interop-layer and is only really feasible after #70. That would mean a class that has all the [hooks](https://www.chartjs.org/docs/latest/developers/plugins.html#plugin-core-api) as `IMethodHandler` properties which are respected on the interop level. This way you could write C# only plugins for chart.js (what madness) but that's an issue for another day.

I have also improved some summaries on the fly just because I was in those classes. In general we don't want to change anything other than what we're actively working on but this is so minor that I thought it makes sense.