### PR TITLE
Update RadarDataser.cs Data varariable as int

### DIFF
--- a/src/ChartJs.Blazor/ChartJS/RadarChart/RadarDataset.cs
+++ b/src/ChartJs.Blazor/ChartJS/RadarChart/RadarDataset.cs
@@ -125,6 +125,6 @@ namespace ChartJs.Blazor.ChartJS.RadarChart
         /// </summary>
         public IndexableOption<int> PointHoverRadius { get; set; }
 
-        public List<double> Data { get; set; }
+        public List<int> Data { get; set; }
     }
 }


### PR DESCRIPTION
Data variable in RadarDataset class of the RadarChartComponent is a double type list. Instead of doing a _rand.NextDouble() to assign the chart distribution double values, I would like to give int values for distribution on radar chart. But the Data variable defined in the RadarDataset class only takes a list with double type.