### PR TITLE
Added Line Chart Interpolation sample

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,9 @@ trim_trailing_whitespace = true
 [project.json]
 indent_size = 2
 
+[samples.json]
+indent_size = 2
+
 # C# files
 [*.cs]
 # New line preferences

--- a/ChartJs.Blazor.Samples/Client/Pages/Charts/Line/Interpolation.razor
+++ b/ChartJs.Blazor.Samples/Client/Pages/Charts/Line/Interpolation.razor
@@ -1,0 +1,125 @@
+﻿@page "/charts/line/interpolation"
+@using ChartJs.Blazor.LineChart
+@layout SampleLayout
+
+<Chart Config="_config" @ref="_chart"></Chart>
+
+<button @onclick="RandomizeData">Randomize Data</button>
+
+@code {
+    private const int InitalCount = 7;
+    private int?[] datapoints;
+    Random rand = new Random();
+    private LineConfig _config;
+    private Chart _chart;
+
+    protected override void OnInitialized()
+    {
+        datapoints = new int?[] { 0, 20, 20, 60, 60, 120, null, 180, 120, 125, 105, 110, 170 };
+
+        IEnumerable<string> labels = new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12" };
+
+        _config = new LineConfig
+        {
+            Options = new LineOptions
+            {
+                Responsive = true,
+                Title = new OptionsTitle
+                {
+                    Display = true,
+                    Text = "ChartJs.Blazor Line Chart - Cubic interpolation mode"
+                },
+                Tooltips = new Tooltips
+                {
+                    Mode = InteractionMode.Nearest,
+                    Intersect = true
+                },
+                Hover = new Hover
+                {
+                    Mode = InteractionMode.Nearest,
+                    Intersect = true
+                },
+                Scales = new Scales
+                {
+
+                    XAxes = new List<CartesianAxis>
+                {
+                        new CategoryAxis
+                        {
+                            ScaleLabel = new ScaleLabel
+                            {
+                                LabelString = "Month"
+                            }
+                        }
+                    },
+                    YAxes = new List<CartesianAxis>
+                {
+                        new LinearCartesianAxis
+                        {
+                            ScaleLabel = new ScaleLabel
+                            {
+                                LabelString = "Value",
+                                Display = true
+                            },
+                            Ticks = new LinearCartesianTicks
+                            {
+                                SuggestedMin = -10,
+                                SuggestedMax = 200
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        IDataset<int?> dataset1 = new LineDataset<int?>(datapoints)
+        {
+            Label = "Cubic interpolation (monotone)",
+            BackgroundColor = ColorUtil.FromDrawingColor(ChartColors.Red),
+            BorderColor = ColorUtil.FromDrawingColor(ChartColors.Red),
+            Fill = FillingMode.Disabled,
+            CubicInterpolationMode = CubicInterpolationMode.Monotone,
+            LineTension = 0.4
+        };
+        IDataset<int?> dataset2 = new LineDataset<int?>(datapoints)
+        {
+            Label = "Cubic interpolation",
+            BackgroundColor = ColorUtil.FromDrawingColor(ChartColors.Blue),
+            BorderColor = ColorUtil.FromDrawingColor(ChartColors.Blue),
+            Fill = FillingMode.Disabled,
+            LineTension = 0.4
+        };
+
+        IDataset<int?> dataset3 = new LineDataset<int?>(datapoints)
+        {
+            Label = "Linear interpolation (default)",
+            BackgroundColor = ColorUtil.FromDrawingColor(ChartColors.Green),
+            BorderColor = ColorUtil.FromDrawingColor(ChartColors.Green),
+            Fill = FillingMode.Disabled,
+            LineTension = 0
+
+        };
+
+        _config.Data.Labels.AddRange(labels);
+        _config.Data.Datasets.Add(dataset1);
+        _config.Data.Datasets.Add(dataset2);
+        _config.Data.Datasets.Add(dataset3);
+    }
+
+    private void RandomizeData()
+    {
+
+        for(int i = 0; i < datapoints.Count(); i++)
+        {
+            datapoints[i] = rand.NextDouble() < 0.05 ? null : (int?)RandomScalingFactor();
+        }
+
+        foreach (IDataset<int?> dataset in _config.Data.Datasets)
+        {
+            dataset.Clear();
+            dataset.AddRange(datapoints);
+        }
+
+        _chart.Update();
+    }
+}

--- a/ChartJs.Blazor.Samples/Client/Pages/Charts/Line/Interpolation.razor
+++ b/ChartJs.Blazor.Samples/Client/Pages/Charts/Line/Interpolation.razor
@@ -7,17 +7,15 @@
 <button @onclick="RandomizeData">Randomize Data</button>
 
 @code {
-    private const int InitalCount = 7;
-    private int?[] datapoints;
-    Random rand = new Random();
+    private const int InitalCount = 12;
+    private int?[] _datapoints;
+    private Random _rng = new Random();
     private LineConfig _config;
     private Chart _chart;
 
     protected override void OnInitialized()
     {
-        datapoints = new int?[] { 0, 20, 20, 60, 60, 120, null, 180, 120, 125, 105, 110, 170 };
-
-        IEnumerable<string> labels = new string[] { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12" };
+        _datapoints = new int?[] { 0, 20, 20, 60, 60, 120, null, 180, 120, 125, 105, 110, 170 };
 
         _config = new LineConfig
         {
@@ -41,19 +39,15 @@
                 },
                 Scales = new Scales
                 {
-
                     XAxes = new List<CartesianAxis>
-                {
+                    {
                         new CategoryAxis
                         {
-                            ScaleLabel = new ScaleLabel
-                            {
-                                LabelString = "Month"
-                            }
+                            ScaleLabel = new ScaleLabel()
                         }
-                    },
+                        },
                     YAxes = new List<CartesianAxis>
-                {
+                    {
                         new LinearCartesianAxis
                         {
                             ScaleLabel = new ScaleLabel
@@ -72,7 +66,7 @@
             }
         };
 
-        IDataset<int?> dataset1 = new LineDataset<int?>(datapoints)
+        IDataset<int?> dataset1 = new LineDataset<int?>(_datapoints)
         {
             Label = "Cubic interpolation (monotone)",
             BackgroundColor = ColorUtil.FromDrawingColor(ChartColors.Red),
@@ -81,26 +75,26 @@
             CubicInterpolationMode = CubicInterpolationMode.Monotone,
             LineTension = 0.4
         };
-        IDataset<int?> dataset2 = new LineDataset<int?>(datapoints)
+
+        IDataset<int?> dataset2 = new LineDataset<int?>(_datapoints)
         {
-            Label = "Cubic interpolation",
+            Label = "Cubic interpolation (default)",
             BackgroundColor = ColorUtil.FromDrawingColor(ChartColors.Blue),
             BorderColor = ColorUtil.FromDrawingColor(ChartColors.Blue),
             Fill = FillingMode.Disabled,
             LineTension = 0.4
         };
 
-        IDataset<int?> dataset3 = new LineDataset<int?>(datapoints)
+        IDataset<int?> dataset3 = new LineDataset<int?>(_datapoints)
         {
-            Label = "Linear interpolation (default)",
+            Label = "Linear interpolation",
             BackgroundColor = ColorUtil.FromDrawingColor(ChartColors.Green),
             BorderColor = ColorUtil.FromDrawingColor(ChartColors.Green),
             Fill = FillingMode.Disabled,
             LineTension = 0
-
         };
 
-        _config.Data.Labels.AddRange(labels);
+        _config.Data.Labels.AddRange(Enumerable.Range(0, InitalCount).Select(i => i.ToString()));
         _config.Data.Datasets.Add(dataset1);
         _config.Data.Datasets.Add(dataset2);
         _config.Data.Datasets.Add(dataset3);
@@ -108,16 +102,15 @@
 
     private void RandomizeData()
     {
-
-        for(int i = 0; i < datapoints.Count(); i++)
+        for(int i = 0; i < _datapoints.Count(); i++)
         {
-            datapoints[i] = rand.NextDouble() < 0.05 ? null : (int?)RandomScalingFactor();
+            _datapoints[i] = _rng.NextDouble() < 0.05 ? null : (int?)RandomScalingFactor();
         }
 
         foreach (IDataset<int?> dataset in _config.Data.Datasets)
         {
             dataset.Clear();
-            dataset.AddRange(datapoints);
+            dataset.AddRange(_datapoints);
         }
 
         _chart.Update();

--- a/ChartJs.Blazor.Samples/Server/samples.json
+++ b/ChartJs.Blazor.Samples/Server/samples.json
@@ -23,10 +23,14 @@
         "Title": "Basic",
         "Path": "charts/line/basic"
       },
-      {
-        "Title": "Stepped",
-        "Path": "charts/line/stepped"
-      }
+        {
+            "Title": "Stepped",
+            "Path": "charts/line/stepped"
+        },
+        {
+            "Title": "Interpolation",
+            "Path": "charts/line/interpolation"
+        }
     ]
   },
   {

--- a/ChartJs.Blazor.Samples/Server/samples.json
+++ b/ChartJs.Blazor.Samples/Server/samples.json
@@ -23,14 +23,14 @@
         "Title": "Basic",
         "Path": "charts/line/basic"
       },
-        {
-            "Title": "Stepped",
-            "Path": "charts/line/stepped"
-        },
-        {
-            "Title": "Interpolation",
-            "Path": "charts/line/interpolation"
-        }
+      {
+        "Title": "Stepped",
+        "Path": "charts/line/stepped"
+      },
+      {
+        "Title": "Interpolation",
+        "Path": "charts/line/interpolation"
+      }
     ]
   },
   {


### PR DESCRIPTION
Issue #122 
[Original sample](https://www.chartjs.org/samples/latest/charts/line/interpolation-modes.html)
[Original sourcecode](https://github.com/chartjs/Chart.js/blob/master/samples/charts/line/interpolation-modes.html)

I want to contribute to the samples. I've added a sample for the interpolation-modes in ChartJS. I'm fairly new to the github-community (not C# or dotnet-core though) so I apologize if I should have made anything different in submitting this PR. Please let me know if you want me to improve anything in the code.

I made a copy of the `Pages/Charts/Line/Basic.razor`-file and modified it. The original sample had NaN-values in it so i modified the line to include `int?`-valuesit as well.